### PR TITLE
Implement shader-driven glitter rendering

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -26,6 +26,7 @@ const BOUNDARY_SENSITIVITY = 8.1;
 
 // MARK: Globals
 
+
 var model = null
 var shouldActOnMouseHover = false
 var eraseMode = false

--- a/shaders/glitter.frag
+++ b/shaders/glitter.frag
@@ -42,14 +42,14 @@ void main() {
     vec3 baseColor = strokeSample.rgb;
 
     vec2 pixelUV = uv * uResolution;
-    float sparkleSeed = hash(floor(pixelUV * 0.6));
+    float sparkleSeed = hash(floor(pixelUV * 0.35));
     float twinkle = sin(uTime * 6.0 + sparkleSeed * 40.0);
-    float grain = noise(pixelUV * 2.4 + twinkle);
-    float sparkle = smoothstep(0.35, 1.0, max(grain, sparkleSeed));
-    float highlight = smoothstep(0.5, 1.0, sin(uTime * 9.0 + sparkleSeed * 20.0) * 0.5 + 0.5);
+    float grain = noise(pixelUV * 1.8 + twinkle);
+    float sparkle = smoothstep(0.2, 1.0, max(grain, sparkleSeed));
+    float highlight = smoothstep(0.35, 1.0, sin(uTime * 9.0 + sparkleSeed * 20.0) * 0.5 + 0.5);
 
-    vec3 sparkleLift = baseColor * (1.1 + sparkle * 0.65) + vec3(sparkle) * 0.1;
-    vec3 highlightLift = mix(baseColor, sparkleLift, 0.45 + 0.45 * highlight);
+    vec3 sparkleLift = baseColor * (1.0 + sparkle * 0.25) + vec3(0.05) * sparkle;
+    vec3 highlightLift = mix(baseColor, sparkleLift, 0.4 + 0.3 * highlight);
     float boardGlow = mix(0.08, 0.25, uDarkMode);
     vec3 glow = vec3(boardGlow * sparkleSeed * 0.3);
 

--- a/shaders/glitter.frag
+++ b/shaders/glitter.frag
@@ -1,0 +1,52 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform sampler2D uMask;
+uniform vec2 uResolution;
+uniform float uTime;
+uniform vec3 uInkColor;
+uniform vec3 uSparkleColor;
+uniform float uDarkMode;
+
+varying vec2 vTexCoord;
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float noise(vec2 uv) {
+    vec2 i = floor(uv);
+    vec2 f = fract(uv);
+
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+
+    vec2 u = f * f * (3.0 - 2.0 * f);
+
+    return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+void main() {
+    float mask = texture2D(uMask, vTexCoord).a;
+    if (mask < 0.01) {
+        discard;
+    }
+
+    vec2 uv = vTexCoord * uResolution;
+    float sparkleSeed = hash(floor(uv * 0.6));
+    float twinkle = sin(uTime * 6.0 + sparkleSeed * 40.0);
+    float grain = noise(uv * 2.4 + twinkle);
+    float sparkle = smoothstep(0.55, 1.0, max(grain, sparkleSeed));
+
+    float highlight = smoothstep(0.75, 1.0, sin(uTime * 9.0 + sparkleSeed * 20.0) * 0.5 + 0.5);
+    vec3 base = mix(uInkColor, uSparkleColor, sparkle);
+    vec3 accent = mix(base, uSparkleColor, highlight);
+    float boardGlow = mix(0.08, 0.25, uDarkMode);
+    vec3 color = accent + vec3(boardGlow) * sparkleSeed * 0.2;
+
+    gl_FragColor = vec4(color, clamp(mask, 0.0, 1.0));
+}

--- a/shaders/glitter.frag
+++ b/shaders/glitter.frag
@@ -42,14 +42,14 @@ void main() {
     vec3 baseColor = strokeSample.rgb;
 
     vec2 pixelUV = uv * uResolution;
-    float sparkleSeed = hash(floor(pixelUV * 0.35));
-    float twinkle = sin(uTime * 6.0 + sparkleSeed * 40.0);
+    float sparkleSeed = hash(floor(pixelUV * 0.2));
+    float twinkle = sin(uTime * 10.0 + sparkleSeed * 10.0);
     float grain = noise(pixelUV * 1.8 + twinkle);
     float sparkle = smoothstep(0.2, 1.0, max(grain, sparkleSeed));
-    float highlight = smoothstep(0.35, 1.0, sin(uTime * 9.0 + sparkleSeed * 20.0) * 0.5 + 0.5);
+    float highlight = smoothstep(0.5, 1.0, sin(uTime * 9.0 + sparkleSeed * 10.0) * 0.5 + 0.5);
 
-    vec3 sparkleLift = baseColor * (1.0 + sparkle * 0.25) + vec3(0.05) * sparkle;
-    vec3 highlightLift = mix(baseColor, sparkleLift, 0.4 + 0.3 * highlight);
+    vec3 sparkleLift = baseColor * (1.0 + sparkle * 0.25) + vec3(0.03) * sparkle;
+    vec3 highlightLift = mix(baseColor, sparkleLift, 0.3 + 0.5 * highlight);
     float boardGlow = mix(0.08, 0.25, uDarkMode);
     vec3 glow = vec3(boardGlow * sparkleSeed * 0.3);
 

--- a/shaders/glitter.frag
+++ b/shaders/glitter.frag
@@ -48,8 +48,8 @@ void main() {
     float sparkle = smoothstep(0.2, 1.0, max(grain, sparkleSeed));
     float highlight = smoothstep(0.5, 1.0, sin(uTime * 9.0 + sparkleSeed * 10.0) * 0.5 + 0.5);
 
-    vec3 sparkleLift = baseColor * (1.0 + sparkle * 0.25) + vec3(0.03) * sparkle;
-    vec3 highlightLift = mix(baseColor, sparkleLift, 0.3 + 0.5 * highlight);
+    vec3 sparkleLift = baseColor * (1.0 + sparkle * 0.4) + vec3(0.03) * sparkle;
+    vec3 highlightLift = mix(baseColor, sparkleLift, 0.2 + 0.5 * highlight);
     float boardGlow = mix(0.08, 0.25, uDarkMode);
     vec3 glow = vec3(boardGlow * sparkleSeed * 0.3);
 

--- a/shaders/glitter.vert
+++ b/shaders/glitter.vert
@@ -6,9 +6,14 @@ precision mediump int;
 attribute vec3 aPosition;
 attribute vec2 aTexCoord;
 
+uniform mat4 uProjectionMatrix;
+uniform mat4 uModelViewMatrix;
+
 varying vec2 vTexCoord;
 
 void main() {
+    // Pass texture coordinates through; fragment shader handles orientation.
     vTexCoord = aTexCoord;
-    gl_Position = vec4(aPosition, 1.0);
+    // Match p5.js default transform pipeline so the quad fills the canvas.
+    gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aPosition, 1.0);
 }

--- a/shaders/glitter.vert
+++ b/shaders/glitter.vert
@@ -1,0 +1,14 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+attribute vec3 aPosition;
+attribute vec2 aTexCoord;
+
+varying vec2 vTexCoord;
+
+void main() {
+    vTexCoord = aTexCoord;
+    gl_Position = vec4(aPosition, 1.0);
+}

--- a/sketch.js
+++ b/sketch.js
@@ -490,55 +490,80 @@ function initializeGraphicsLayers() {
     scheduleMaskRebuild()
 }
 
-function createColorLayer() {
-    colorLayer = createGraphics(windowWidth, windowHeight)
-    colorLayer.pixelDensity(pixelDensity())
-    colorLayer.clear()
-    configureColorLayer()
-}
-
-function configureColorLayer() {
-    if (!colorLayer) {
+function configureColorLayer(layer = colorLayer) {
+    if (!layer) {
         return
     }
-    colorLayer.colorMode(RGB, 255)
-    colorLayer.strokeWeight(FACTORY_STROKE_SIZE)
-    colorLayer.strokeCap(ROUND)
-    colorLayer.strokeJoin(ROUND)
-    colorLayer.noFill()
+    layer.colorMode(RGB, 255)
+    layer.strokeWeight(FACTORY_STROKE_SIZE)
+    layer.strokeCap(ROUND)
+    layer.strokeJoin(ROUND)
+    layer.noFill()
+}
+
+function configureMaskLayer(layer = maskLayer) {
+    if (!layer) {
+        return
+    }
+    layer.stroke(255)
+    layer.strokeWeight(FACTORY_STROKE_SIZE)
+    layer.strokeCap(ROUND)
+    layer.strokeJoin(ROUND)
+    layer.noFill()
+}
+
+function configureOverlayLayer(layer = overlayLayer) {
+    if (!layer) {
+        return
+    }
+    layer.noFill()
+}
+
+function configureGlitterLayer(layer = glitterLayer) {
+    if (!layer) {
+        return
+    }
+    layer.noStroke()
+    layer.rectMode(CENTER)
+    layer.textureMode(NORMAL)
+}
+
+function ensureGraphicsLayer(existingLayer, renderer, configure) {
+    const targetWidth = windowWidth
+    const targetHeight = windowHeight
+
+    let layer = existingLayer
+
+    if (layer) {
+        layer.resizeCanvas(targetWidth, targetHeight)
+    } else {
+        layer = createGraphics(targetWidth, targetHeight, renderer)
+    }
+
+    layer.pixelDensity(pixelDensity())
+    layer.clear()
+
+    if (configure) {
+        configure(layer)
+    }
+
+    return layer
+}
+
+function createColorLayer() {
+    colorLayer = ensureGraphicsLayer(colorLayer, undefined, configureColorLayer)
 }
 
 function createMaskLayer() {
-    maskLayer = createGraphics(windowWidth, windowHeight)
-    maskLayer.pixelDensity(pixelDensity())
-    maskLayer.clear()
-    configureMaskLayer()
-}
-
-function configureMaskLayer() {
-    if (!maskLayer) {
-        return
-    }
-    maskLayer.stroke(255)
-    maskLayer.strokeWeight(FACTORY_STROKE_SIZE)
-    maskLayer.strokeCap(ROUND)
-    maskLayer.strokeJoin(ROUND)
-    maskLayer.noFill()
+    maskLayer = ensureGraphicsLayer(maskLayer, undefined, configureMaskLayer)
 }
 
 function createOverlayLayer() {
-    overlayLayer = createGraphics(windowWidth, windowHeight)
-    overlayLayer.pixelDensity(pixelDensity())
-    overlayLayer.clear()
-    overlayLayer.noFill()
+    overlayLayer = ensureGraphicsLayer(overlayLayer, undefined, configureOverlayLayer)
 }
 
 function createGlitterLayer() {
-    glitterLayer = createGraphics(windowWidth, windowHeight, WEBGL)
-    glitterLayer.pixelDensity(pixelDensity())
-    glitterLayer.noStroke()
-    glitterLayer.rectMode(CENTER)
-    glitterLayer.textureMode(NORMAL)
+    glitterLayer = ensureGraphicsLayer(glitterLayer, WEBGL, configureGlitterLayer)
 }
 
 function recreateGraphicsLayers() {
@@ -546,6 +571,7 @@ function recreateGraphicsLayers() {
     createMaskLayer()
     createGlitterLayer()
     createOverlayLayer()
+    scheduleMaskRebuild()
     rebuildMaskFromModel()
 }
 

--- a/sketch.js
+++ b/sketch.js
@@ -12,7 +12,7 @@
 const FACTORY_STROKE_SIZE = 9
 const LINE_AVERAGING_SENSITIVITY = 7
 const MOUSE_ERASE_SENSITIVITY = LINE_AVERAGING_SENSITIVITY * 1.5
-const MOUSE_HOVER_SENSITIVITY = 70
+const MOUSE_HOVER_SENSITIVITY = 120
 const STORAGE_KEY = "org.pouyakary.pink.model"
 const LOCK_KEY = "org.pouyakary.pink.lock"
 const SELECTION_PADDING = 20
@@ -21,6 +21,15 @@ const SELECTION_BOX_STROKE_WEIGHT = 4
 const DARK_PINK_DELTA = 130
 const LIGHT_PINK_BASE = 145
 const BOUNDARY_SENSITIVITY = 8.1;
+
+const ERASE_BASE_COLOR_LIGHT = [171, 188, 219]
+const ERASE_BASE_COLOR_DARK = [197, 57, 115]
+const ERASE_SELECTED_COLOR_LIGHT = [255, 0, 0]
+const ERASE_SELECTED_COLOR_DARK = [255, 126, 168]
+const HIGHLIGHT_COLOR_LIGHT = [90, 37, 161]
+const HIGHLIGHT_COLOR_DARK = [90, 37, 161]
+const DRAW_COLOR_LIGHT = [199, 21, 133]
+const DRAW_COLOR_DARK = [199, 21, 133]
 
 // ─── Globals ───────────────────────────────────────────────────────────── ✣ ─
 
@@ -769,38 +778,40 @@ function setCursor() {
     }
 }
 
+function applyStroke(painter, color) {
+    if (!color) {
+        return
+    }
+    painter.stroke(color[0], color[1], color[2])
+}
+
 function decideColor(x, y, shouldAllShapeBeSelected, target = null) {
     const painter = target || window
+    const drawBaseColor = darkMode ? DRAW_COLOR_DARK : DRAW_COLOR_LIGHT
+    const highlightColor = darkMode ? HIGHLIGHT_COLOR_DARK : HIGHLIGHT_COLOR_LIGHT
+    const eraseNeutralColor = darkMode ? ERASE_BASE_COLOR_DARK : ERASE_BASE_COLOR_LIGHT
+    const eraseSelectedColor = darkMode ? ERASE_SELECTED_COLOR_DARK : ERASE_SELECTED_COLOR_LIGHT
+
     if (eraseMode) {
-        if (somethingIsSelected) {
-            if (shouldActOnMouseHover) {
-                painter.stroke(pinkBase + random(255 - pinkBase), 0, pinkBase + random(255 - pinkBase)) // pink
-            } else {
-                if (shouldAllShapeBeSelected) {
-                    painter.stroke(random(155) + 100 + pinkBase * 0.4, 0, 0) // red
-                } else {
-                    if (darkMode) {
-                        painter.stroke(random(255 - DARK_PINK_DELTA), 0, random(255 - DARK_PINK_DELTA)) // dark pink
-                    } else {
-                        painter.stroke(171, 188, 219) // a solid magenta that matches the light background
-                    }
-                }
-            }
-        } else {
-            painter.stroke(pinkBase + random(255 - pinkBase), 0, pinkBase + random(255 - pinkBase)) // pink
+        if (shouldAllShapeBeSelected) {
+            applyStroke(painter, eraseSelectedColor)
+            return
         }
+
+        if (somethingIsSelected && shouldActOnMouseHover) {
+            applyStroke(painter, highlightColor)
+            return
+        }
+
+        applyStroke(painter, eraseNeutralColor)
+        return
+    }
+
+    const radius = length(x, y, mouseX, mouseY)
+    if (radius < MOUSE_HOVER_SENSITIVITY) {
+        applyStroke(painter, highlightColor)
     } else {
-        const radius = length(x, y, mouseX, mouseY)
-        if (radius < MOUSE_HOVER_SENSITIVITY) {
-            if (darkMode) {
-                painter.stroke(0, random(255), random(100)) // green
-            } else {
-                const base = random(150)
-                painter.stroke(base, base, base + 155 + random(150 - base)) // blue
-            }
-        } else {
-            painter.stroke(pinkBase + random(255 - pinkBase), 0, pinkBase + random(255 - pinkBase)) // pink
-        }
+        applyStroke(painter, drawBaseColor)
     }
 }
 
@@ -828,7 +839,7 @@ function setAppearanceColors() {
         background(0)
         pinkBase = 0
     } else {
-        background(235, 242, 255)
+        background(255, 190, 215)
         pinkBase = LIGHT_PINK_BASE
     }
 }

--- a/style.css
+++ b/style.css
@@ -1,250 +1,252 @@
-
 * {
-    box-sizing:             border-box;
-    user-select:            none;
-    -moz-user-select:       none;
-    -webkit-user-select:    none;
-    -ms-user-select:        none;
+  box-sizing: border-box;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }
 
-body, html {
-    margin:                 0;
-    padding:                0;
-    overflow:               hidden;
-    background-color:       rgb(235, 242, 255);
-    font-family:            -apple-system, helvetica, arial, sans-serif;
+body,
+html {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background-color: rgb(235, 242, 255);
+  font-family: -apple-system, helvetica, arial, sans-serif;
 }
 
 canvas {
-    display:    block;
+  display: block;
 }
 
 .buttons-bar {
-    position:           absolute;
-    display:            flex;
-    justify-content:    space-between;
-    z-index:            1000;
-    top:                10pt;
-    top:                calc(env(safe-area-inset-top) + 10pt);
-    right:              10pt;
-    right:              calc(env(safe-area-inset-right) + 10pt);
-    width:              fit-content;
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  z-index: 1000;
+  top: 10pt;
+  top: calc(env(safe-area-inset-top) + 10pt);
+  right: 10pt;
+  right: calc(env(safe-area-inset-right) + 10pt);
+  width: fit-content;
 }
 
 .bar-button {
-    --button-height:
-        19.5pt;
+  --button-height: 19.5pt;
 
-    font-size:              13pt !important;
-    box-sizing:             border-box;
-    background-color:       rgb(104, 117, 140);
-    color:                  white;
-    border-radius:          var(--button-height);
-    padding:                3pt 9pt 6pt 10pt;
-    height:                 var(--button-height);
-    max-height:             var(--button-height);
-    min-height:             var(--button-height);
-    overflow:               hidden;
-    margin-right:           5pt;
+  font-size: 13pt !important;
+  box-sizing: border-box;
+  background-color: rgb(201, 30, 138);
+  color: rgb(255, 208, 238);
+  border-radius: var(--button-height);
+  padding: 3pt 9pt 6pt 10pt;
+  height: var(--button-height);
+  max-height: var(--button-height);
+  min-height: var(--button-height);
+  overflow: hidden;
+  margin-right: 5pt;
 }
 
 .bar-button.red {
-    background-color:               red !important;
-    color:                          white !important;
-    animation:                      lightAlertAnimation 1s forwards infinite;
-    animation-timing-function:      linear;
+  background-color: red !important;
+  color: white !important;
+  animation: lightAlertAnimation 1s forwards infinite;
+  animation-timing-function: linear;
 }
 
 @keyframes lightAlertAnimation {
-    0% {
-        background-color:       rgb(220, 0, 0);
-    }
-    50% {
-        background-color:       rgb(140, 0, 0);
-    }
-    100% {
-        background-color:       rgb(220, 0, 0);
-    }
+  0% {
+    background-color: rgb(220, 0, 0);
+  }
+  50% {
+    background-color: rgb(140, 0, 0);
+  }
+  100% {
+    background-color: rgb(220, 0, 0);
+  }
 }
 
 @keyframes darkAlertAnimation {
-    from {
-        background-position-x:      0;
-    }
-    to {
-        background-position-x:      var(--button-height);
-    }
+  from {
+    background-position-x: 0;
+  }
+  to {
+    background-position-x: var(--button-height);
+  }
 }
 
 .bar-button:hover {
-    background-color:       black;
-    color:                  white;
-    cursor:                 pointer;
+  background-color: black;
+  color: white;
+  cursor: pointer;
 }
 
-.bar-button:active, .bar-button:focus {
-    background-color:       rgb(78, 78, 78);
+.bar-button:active,
+.bar-button:focus {
+  background-color: rgb(78, 78, 78);
 }
 
 #status {
-    background-color:       inherit;
-    cursor:                 inherit !important;
-    color:                  black;
-    letter-spacing:         1pt;
-    font-size:              9pt !important;
-    padding-top:            4.5pt;
+  background-color: inherit;
+  cursor: inherit !important;
+  color: rgb(160, 24, 110);
+  letter-spacing: 1pt;
+  font-size: 9pt !important;
+  padding-top: 4.5pt;
 }
 
 .drawing-cursor {
-    cursor:     url("pen.svg") 6 3, crosshair !important;
+  cursor: url("pen.svg") 6 3, crosshair !important;
 }
 
 .erasing-cursor {
-    cursor:     url("eraser.svg") 7 6, crosshair !important;
+  cursor: url("eraser.svg") 7 6, crosshair !important;
 }
 
 .pointing-cursor {
-    cursor:     default;
+  cursor: default;
 }
 
 #help-screen {
-    display:                none;
-    background-color:       rgb(104, 117, 140);
-    width:                  100vw;
-    height:                 100vh;
-    z-index:                2000;
-    position:               fixed;
-    left:                   0;
-    top:                    0;
-    overflow:               hidden;
-    color:                  red;
-    cursor:                 pointer;
+  display: none;
+  background-color: rgb(104, 117, 140);
+  width: 100vw;
+  height: 100vh;
+  z-index: 2000;
+  position: fixed;
+  left: 0;
+  top: 0;
+  overflow: hidden;
+  color: red;
+  cursor: pointer;
 }
 
 #help-screen div {
-    margin:             auto;
-    line-height:        1.5;
-    color:              white;
-    padding:            30pt;
-    border-radius:      10pt;
-    max-width:          fit-content;
-    max-height:         fit-content;
+  margin: auto;
+  line-height: 1.5;
+  color: white;
+  padding: 30pt;
+  border-radius: 10pt;
+  max-width: fit-content;
+  max-height: fit-content;
 }
 
 #help-screen a {
-    color:              white;
-    text-decoration:    underline;
+  color: white;
+  text-decoration: underline;
 }
 
 .dialog-container {
-    padding:                20pt;
-    width:                  100vw;
-    background:             white;
-    position:               fixed;
-    z-index:                3000;
-    left:                   0;
-    top:                    0;
-    transition-duration:    0.3s;
-    max-height:             120pt;
-    overflow:               hidden;
+  padding: 20pt;
+  width: 100vw;
+  background: white;
+  position: fixed;
+  z-index: 3000;
+  left: 0;
+  top: 0;
+  transition-duration: 0.3s;
+  max-height: 120pt;
+  overflow: hidden;
 }
 
 .dialog-container.hidden {
-    top:                    -120pt;
-    transition-duration:    0.3s;
+  top: -120pt;
+  transition-duration: 0.3s;
 }
 
 .dialog-box {
-    margin:         auto;
-    max-width:      fit-content;
-    display:        flex;
+  margin: auto;
+  max-width: fit-content;
+  display: flex;
 }
 
 .dialog-emoji {
-    font-size:          2rem;
-    margin-right:       10pt;
-    max-width:          fit-content;
-    flex:               auto;
+  font-size: 2rem;
+  margin-right: 10pt;
+  max-width: fit-content;
+  flex: auto;
 }
 
 .dialog-message-and-buttons {
-    padding-top:    3pt;
+  padding-top: 3pt;
 }
 
 .dialog-message {
-    max-width:          330pt;
-    line-height:        1.5;
-    padding-left:       2pt;
+  max-width: 330pt;
+  line-height: 1.5;
+  padding-left: 2pt;
 }
 
 .dialog-buttons-bar {
-    min-width:      200pt;
-    display:        flex;
-    margin-top:     10pt;
+  min-width: 200pt;
+  display: flex;
+  margin-top: 10pt;
 }
 
 .dialog-button {
-    font-size:              0.9rem;
-    padding:                3pt 11pt 4pt 10pt;
-    background-color:       #eee;
-    border-radius:          30pt;
-    margin-right:           10pt;
-    cursor:                 pointer;
+  font-size: 0.9rem;
+  padding: 3pt 11pt 4pt 10pt;
+  background-color: #eee;
+  border-radius: 30pt;
+  margin-right: 10pt;
+  cursor: pointer;
 }
 
 .dialog-button:hover {
-    background-color:       black;
-    color:                  white;
+  background-color: black;
+  color: white;
 }
 
 @media (prefers-color-scheme: dark) {
-    .bar-button {
-        background-color:       #424242;
-        color:                  white;
-    }
+  .bar-button {
+    background-color: #424242;
+    color: white;
+  }
 
-    #status {
-        color:      white;
-    }
+  #status {
+    color: white;
+  }
 
-    .bar-button:hover {
-        background-color:       #979797;
-        cursor:                 pointer;
-    }
+  .bar-button:hover {
+    background-color: #979797;
+    cursor: pointer;
+  }
 
-    .bar-button:active, .bar-button:focus {
-        background-color:       #636363;
-    }
+  .bar-button:active,
+  .bar-button:focus {
+    background-color: #636363;
+  }
 
-    body, html {
-        background-color:       black;
-    }
+  body,
+  html {
+    background-color: black;
+  }
 
-    .bar-button.red {
-        background-color:               #740000 !important;
-        color:                          #ffe0e0 !important;
-        background-image:               url("erasing.png");
-        background-size:                contain;
-        background-position:            left center;
-        animation:                      darkAlertAnimation 0.5s forwards infinite;
-        animation-timing-function:      linear;
-    }
+  .bar-button.red {
+    background-color: #740000 !important;
+    color: #ffe0e0 !important;
+    background-image: url("erasing.png");
+    background-size: contain;
+    background-position: left center;
+    animation: darkAlertAnimation 0.5s forwards infinite;
+    animation-timing-function: linear;
+  }
 
-    #help-screen {
-        background:     black;
-    }
+  #help-screen {
+    background: black;
+  }
 
-    .dialog-container {
-        background:     #292929;
-        color:          white;
-    }
+  .dialog-container {
+    background: #292929;
+    color: white;
+  }
 
-    .dialog-button {
-        background-color:       #424242;
-    }
+  .dialog-button {
+    background-color: #424242;
+  }
 
-    .dialog-button:hover {
-        background-color:       #eee;
-        color:                  black;
-    }
+  .dialog-button:hover {
+    background-color: #eee;
+    color: black;
+  }
 }


### PR DESCRIPTION
## Summary
- add a persistent mask layer and WebGL shader pipeline so glitter ink is animated on the GPU instead of re-rendered on the CPU each frame
- update the drawing workflow to stream new segments into the mask and rebuild it when the model changes
- add vertex and fragment shaders that animate the glitter effect with procedural noise and time-based twinkling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0eff1a958832dacd59f7336808b1f